### PR TITLE
Add database-backed session tokens for normal login

### DIFF
--- a/includes/class-esp-config.php
+++ b/includes/class-esp-config.php
@@ -39,12 +39,13 @@ class ESP_Config {
                 'critical_error' => true
             )
         ),
-        'db_version' => 1 // DBバージョン
+        'db_version' => 2 // DBバージョン
 
     );
 
     const DB_TABLES = array(
         'remember' => 'esp_login_remember',
-        'brute' => 'esp_login_attempts'
+        'brute' => 'esp_login_attempts',
+        'session' => 'esp_login_session'
     );
 }

--- a/includes/class-esp-cookie.php
+++ b/includes/class-esp-cookie.php
@@ -68,10 +68,13 @@ class ESP_Cookie {
      * @param string $path_id パスID
      * @param string $token トークン
      */
-    public function prepare_session_cookie($path_id, $token) {
+    public function prepare_session_cookie($path_id, $token, $expires = null) {
+        if ($expires === null) {
+            $expires = time() + DAY_IN_SECONDS;
+        }
         $this->pending_cookies['esp_auth_' . $path_id] = [
             'value' => $token,
-            'expires' => time() + DAY_IN_SECONDS
+            'expires' => $expires
         ];
     }
 

--- a/includes/class-esp-logout.php
+++ b/includes/class-esp-logout.php
@@ -153,6 +153,7 @@ class ESP_Logout {
         $path_id = $path_settings['id'];
         
         // DBデータのクリア
+        $session_token = $this->cookie->get_session_cookie($path_id);
         $cookie_data = $this->cookie->get_remember_cookies_for_path($path_settings);
         if ($cookie_data) {
             global $wpdb;
@@ -165,7 +166,19 @@ class ESP_Logout {
                 array('%s', '%s')
             );
         }
-        
+
+        if ($session_token) {
+            global $wpdb;
+            $wpdb->delete(
+                $wpdb->prefix . ESP_Config::DB_TABLES['session'],
+                array(
+                    'token' => hash_hmac('sha256', $session_token, AUTH_SALT),
+                    'path_id' => $path_id
+                ),
+                array('%s', '%s')
+            );
+        }
+
         // Cookieのクリア
         $this->cookie->clear_all_cookies_for_path($path_settings);
     }

--- a/includes/class-esp-security.php
+++ b/includes/class-esp-security.php
@@ -272,4 +272,13 @@ class ESP_Security {
         $table = $wpdb->prefix . ESP_Config::DB_TABLES['remember'];
         $wpdb->query("DELETE FROM {$table} WHERE expires < NOW()");
     }
+
+    /**
+     * Cron用の通常ログインセッションクリーンアップ
+     */
+    public static function cron_cleanup_sessions() {
+        global $wpdb;
+        $table = $wpdb->prefix . ESP_Config::DB_TABLES['session'];
+        $wpdb->query("DELETE FROM {$table} WHERE expires < NOW()");
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated esp_login_session table and migration to persist normal login tokens
- store, verify, and clean up session tokens just like remember tokens, including logout handling
- extend cookie handling to pass explicit expirations and schedule cron cleanup for session tokens

## Testing
- php -l includes/class-esp-auth.php
- php -l includes/class-esp-config.php
- php -l includes/class-esp-cookie.php
- php -l includes/class-esp-logout.php
- php -l includes/class-esp-security.php
- php -l includes/class-esp-setup.php

------
https://chatgpt.com/codex/tasks/task_e_68cb50801bec83309490f7ebd40276b6