### PR TITLE
Add password versioning for remember tokens

### DIFF
--- a/front/esp-styles.css
+++ b/front/esp-styles.css
@@ -54,15 +54,29 @@
 
 /* エラーメッセージ */
 .esp-error {
-	/* color: #dc3232; */
-	padding: 10px;
-	margin-bottom: 1.5em;
-	/* border-left: 4px solid #dc3232; */
-	/* background: #fff; */
-	font-weight: bold;
-	color: #fff;
-	background-color: #dc3232;
-	border-radius: 10px;
+        /* color: #dc3232; */
+        padding: 10px;
+        margin-bottom: 1.5em;
+        /* border-left: 4px solid #dc3232; */
+        /* background: #fff; */
+        font-weight: bold;
+        color: #fff;
+        background-color: #dc3232;
+        border-radius: 10px;
+}
+
+.esp-notice {
+        padding: 10px;
+        margin-bottom: 1.5em;
+        font-weight: bold;
+        color: #1d2327;
+        background-color: #e5f4ff;
+        border-radius: 10px;
+}
+
+.esp-notice--warning {
+        color: #1d2327;
+        background-color: #ffb900;
 }
 
 /* ログアウトボタン */

--- a/includes/class-esp-config.php
+++ b/includes/class-esp-config.php
@@ -39,7 +39,7 @@ class ESP_Config {
                 'critical_error' => true
             )
         ),
-        'db_version' => 2 // DBバージョン
+        'db_version' => 3 // DBバージョン
 
     );
 


### PR DESCRIPTION
## Summary
- track a password_version value on each protected path when sanitizing admin input so changes bump the version counter
- add a password_version column to remember tokens, bump the schema version, and migrate existing options/tables accordingly
- validate remember tokens against the current password_version, clearing stale tokens while surfacing a warning message with the updated front-end styles
- insert concise Japanese comments explaining the password version handling

## Testing
- php -l admin/classes/class-esp-admin-sanitize.php
- php -l includes/class-esp-auth.php
- php -l includes/class-esp-setup.php
- php -l includes/class-esp-config.php

------
https://chatgpt.com/codex/tasks/task_e_68cb6853a2a0833092cb8fb0e27d8655