### PR TITLE
Improve .htaccess reset handling

### DIFF
--- a/admin/classes/class-esp-admin-assets.php
+++ b/admin/classes/class-esp-admin-assets.php
@@ -40,6 +40,11 @@ class ESP_Admin_Assets {
             'clearingMediaCache' => __('メディアキャッシュをクリア中...', $plugin_name),
             'clearMediaCacheButton' => __('メディア保護キャッシュをクリアする', $plugin_name),
             'clearMediaCacheError' => __('メディアキャッシュのクリア中にエラーが発生しました。', $plugin_name),
+            'confirmResetHtaccess' => __('.htaccessルールを再設定します。よろしいですか？', $plugin_name),
+            'resettingHtaccess' => __('再設定中...', $plugin_name),
+            'resetHtaccessButton' => __('.htaccessのルールを再設定する', $plugin_name),
+            'resetHtaccessSuccess' => __('.htaccessのルールを再設定しました。', $plugin_name),
+            'resetHtaccessError' => __('.htaccessの再設定中にエラーが発生しました。', $plugin_name),
             'ajaxError' => __('AJAXリクエストに失敗しました:', $plugin_name),
         );
     }
@@ -88,6 +93,7 @@ class ESP_Admin_Assets {
                 'regenerateNonce' => wp_create_nonce('esp_regenerate_permalinks_nonce'), // メタデータ再生成用Nonce
                 'clearCacheNonce' => wp_create_nonce('esp_clear_cache_nonce'),// キャッシュクリア用Nonce
                 'clearMediaCacheNonce' => wp_create_nonce('esp_clear_media_cache_nonce'),// メディア保護キャッシュ用
+                'resetHtaccessNonce' => wp_create_nonce('esp_reset_htaccess_nonce'),// .htaccessルール再設定用Nonce
                 'i18n' => $this::localize_data()
             )
         );

--- a/admin/classes/class-esp-admin-menu.php
+++ b/admin/classes/class-esp-admin-menu.php
@@ -388,9 +388,21 @@ class ESP_Admin_Menu {
                                 <div id="esp-clear-media-cache-status" style="margin-top: 5px;"></div>
                             </td>
                         </tr>
+                        <tr>
+                            <th scope="row"><?php _e('.htaccessルール再設定', $text_domain); ?></th>
+                            <td>
+                                <button type="button" class="button button-secondary" id="esp-reset-htaccess-rules">
+                                    <?php _e('.htaccessのルールを再設定する', $text_domain); ?>
+                                </button>
+                                <p class="description">
+                                    <?php _e('アップロードディレクトリの.htaccessルールを再生成します。Apache/LiteSpeed環境でメディア保護に問題がある場合に使用してください。', $text_domain); ?>
+                                </p>
+                                <div id="esp-reset-htaccess-status" style="margin-top: 5px;"></div>
+                            </td>
+                        </tr>
                     </table>
                 </div>
-                
+
                 <?php submit_button(); ?>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- enhance the admin reset handler to reuse localized strings and display notices consistently
- add a dedicated localized success message for regenerating upload .htaccess rules
- harden the server-side .htaccess writer with WP_Filesystem support and rich error feedback for AJAX responses

## Testing
- php -l admin/classes/class-esp-admin-assets.php
- php -l admin/classes/class-esp-admin-menu.php
- php -l includes/class-esp-media-protection.php

------
https://chatgpt.com/codex/tasks/task_e_68cb9238d2dc8330817b4edebfff24fc