### PR TITLE
Add option to exclude passwords from email notifications

### DIFF
--- a/admin/classes/class-esp-admin-menu.php
+++ b/admin/classes/class-esp-admin-menu.php
@@ -285,7 +285,10 @@ class ESP_Admin_Menu {
                             <td>
                                 <fieldset class="esp-notification-items">
                                     <!-- デフォルトで通知項目配列が存在することを保証 -->
-                                    <?php $notifications = isset($mail_settings['notifications']) ? $mail_settings['notifications'] : array(); ?>
+                                    <?php
+                                        $notifications = isset($mail_settings['notifications']) ? $mail_settings['notifications'] : array();
+                                        $include_password = !empty($mail_settings['include_password']);
+                                    ?>
                                     
                                     <label <?php echo !$mail_settings['enable_notifications'] ? 'class="esp-disabled"' : ''; ?>>
                                         <input type="checkbox" 
@@ -338,6 +341,27 @@ class ESP_Admin_Menu {
                                 </fieldset>
                                 <p class="description">
                                     <?php _e('通知メールは管理者権限を持つすべてのユーザーに送信されます。', $text_domain); ?>
+                                </p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">
+                                <label for="esp-include-password-in-email">
+                                    <?php _e('通知メールのパスワード', $text_domain); ?>
+                                </label>
+                            </th>
+                            <td>
+                                <label <?php echo !$mail_settings['enable_notifications'] ? 'class="esp-disabled"' : ''; ?>>
+                                    <input type="checkbox"
+                                        id="esp-include-password-in-email"
+                                        name="<?php echo $option_key; ?>[mail][include_password]"
+                                        value="1"
+                                        <?php checked($include_password); ?>
+                                        <?php disabled(!$mail_settings['enable_notifications']); ?>>
+                                    <?php _e('通知メールにパスワードを含める', $text_domain); ?>
+                                </label>
+                                <p class="description">
+                                    <?php _e('セキュリティ上の理由でパスワードをメールに含めたくない場合はチェックを外してください。', $text_domain); ?>
                                 </p>
                             </td>
                         </tr>

--- a/admin/classes/class-esp-admin-sanitize.php
+++ b/admin/classes/class-esp-admin-sanitize.php
@@ -210,6 +210,9 @@ class ESP_Sanitize {
             $sanitized_settings['notifications'][$key] = !empty($settings['notifications'][$key]) ? true : false;
         }
 
+        // パスワードをメールに含めるかどうか
+        $sanitized_settings['include_password'] = !empty($settings['include_password']) ? true : false;
+
         return $sanitized_settings;
     }
 }

--- a/includes/class-esp-config.php
+++ b/includes/class-esp-config.php
@@ -31,6 +31,7 @@ class ESP_Config {
         ),
         'mail' => array(
             'enable_notifications' => true,
+            'include_password' => true,
             'notifications' => array(
                 'new_path' => true,
                 'password_change' => true,

--- a/includes/class-esp-mail.php
+++ b/includes/class-esp-mail.php
@@ -62,6 +62,16 @@ class ESP_Mail {
     }
 
     /**
+     * メールにパスワードを含めるかどうかを判定
+     *
+     * @return bool
+     */
+    private function should_include_password_in_email() {
+        $settings = ESP_Option::get_current_setting('mail');
+        return !empty($settings['include_password']);
+    }
+
+    /**
      * メール送信のラッパー関数
      * 
      * @param string $subject 件名
@@ -117,7 +127,12 @@ class ESP_Mail {
 
         $message = "新しい保護パスが追加されました。\n\n";
         $message .= "保護パス: {$path}\n";
-        $message .= "パスワード: {$password}\n\n";
+
+        if ($this->should_include_password_in_email()) {
+            $message .= "パスワード: {$password}\n\n";
+        } else {
+            $message .= "パスワードはこのメールには含まれていません。管理画面でご確認ください。\n\n";
+        }
         $message .= "このメールは " . home_url() . " より自動送信されています。";
 
         return $this->send_mail($subject, $message);
@@ -141,7 +156,12 @@ class ESP_Mail {
 
         $message = "保護パスのパスワードが変更されました。\n\n";
         $message .= "保護パス: {$path}\n";
-        $message .= "新しいパスワード: {$new_password}\n\n";
+
+        if ($this->should_include_password_in_email()) {
+            $message .= "新しいパスワード: {$new_password}\n\n";
+        } else {
+            $message .= "新しいパスワードはこのメールには含まれていません。管理画面でご確認ください。\n\n";
+        }
         $message .= "このメールは " . home_url() . " より自動送信されています。";
 
         return $this->send_mail($subject, $message);


### PR DESCRIPTION
## Summary
- add a mail setting toggle to control whether passwords are included in notification emails
- update notification emails to omit passwords when disabled and guide admins to the dashboard
- ensure mail option defaults include the new flag and merge safely with stored settings

## Testing
- php -l includes/class-esp-config.php
- php -l includes/class-esp-option.php
- php -l admin/classes/class-esp-admin-sanitize.php
- php -l admin/classes/class-esp-admin-menu.php
- php -l includes/class-esp-mail.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe4bec9448330a4e158d31ebf74d4