### PR TITLE
Invalidate session logins after password changes

### DIFF
--- a/includes/class-esp-config.php
+++ b/includes/class-esp-config.php
@@ -40,7 +40,7 @@ class ESP_Config {
                 'critical_error' => true
             )
         ),
-        'db_version' => 3 // DBバージョン
+        'db_version' => 4 // DBバージョン
 
     );
 


### PR DESCRIPTION
## Summary
- store password_version with session login records and invalidate them when passwords change
- add database migration and schema updates to include password_version column for session logins
- bump required database version to trigger the new migration

## Testing
- php -l includes/class-esp-auth.php
- php -l includes/class-esp-setup.php
- php -l includes/class-esp-config.php

------
https://chatgpt.com/codex/tasks/task_e_68d1017568c083309eea7daf93efbf12