### PR TITLE
Run migration check on plugins_loaded

### DIFF
--- a/easy-slug-protect.php
+++ b/easy-slug-protect.php
@@ -72,12 +72,12 @@ class Easy_Slug_Protect {
      * プラグインの初期化
      */
     private function init() {
+        // バージョンチェックと更新は常に実行
+        $this->setup->check_plugin_version();
+
         if (is_admin()) {
             // 管理画面の初期化
             new ESP_Admin_page();
-
-            // バージョンチェックと更新
-            add_action('admin_init', [$this->setup, 'check_plugin_version']);
         } else {
             // コア機能の初期化
             $core = new ESP_Core();


### PR DESCRIPTION
## Summary
- プラグイン初期化時に常にバージョンチェックを実行し、管理画面以外のリクエストでもマイグレーションできるようにしました
- admin_init に紐づいていた冗長なバージョンチェックフックを削除しました

## Testing
- php -l easy-slug-protect.php

------
https://chatgpt.com/codex/tasks/task_e_68d129753ab4833099dbc6e79b0353ad