### PR TITLE
Adjust media delivery options

### DIFF
--- a/admin/classes/class-esp-admin-menu.php
+++ b/admin/classes/class-esp-admin-menu.php
@@ -83,6 +83,8 @@ class ESP_Admin_Menu {
         $bruteforce_settings = ESP_Option::get_current_setting('brute');
         $remember_settings = ESP_Option::get_current_setting('remember');
         $mail_settings =  ESP_Option::get_current_setting('mail');
+        $media_settings = ESP_Option::get_current_setting('media');
+        $delivery_method = isset($media_settings['delivery_method']) ? $media_settings['delivery_method'] : 'auto';
 
         $text_domain = ESP_Config::TEXT_DOMAIN;
         $option_key = ESP_Config::OPTION_KEY;
@@ -411,6 +413,37 @@ class ESP_Admin_Menu {
                                 </label>
                                 <p class="description">
                                     <?php _e('セキュリティ上の理由でパスワードをメールに含めたくない場合はチェックを外してください。', $text_domain); ?>
+                                </p>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+
+                <div class="esp-section">
+                    <h2><?php _e('メディア配信設定', $text_domain); ?></h2>
+                    <table class="form-table">
+                        <tr>
+                            <th scope="row"><?php _e('配信方法', $text_domain); ?></th>
+                            <td>
+                                <select name="<?php echo $option_key; ?>[media][delivery_method]" class="regular-text">
+                                    <option value="auto" <?php selected($delivery_method, 'auto'); ?>>
+                                        <?php _e('自動判定（利用可能な方法を選択）', $text_domain); ?>
+                                    </option>
+                                    <option value="x_sendfile" <?php selected($delivery_method, 'x_sendfile'); ?>>
+                                        <?php _e('X-Sendfile（Apache系で利用）', $text_domain); ?>
+                                    </option>
+                                    <option value="litespeed" <?php selected($delivery_method, 'litespeed'); ?>>
+                                        <?php _e('X-LiteSpeed-Location（LiteSpeed用）', $text_domain); ?>
+                                    </option>
+                                    <option value="x_accel_redirect" <?php selected($delivery_method, 'x_accel_redirect'); ?>>
+                                        <?php _e('X-Accel-Redirect（Nginx用）', $text_domain); ?>
+                                    </option>
+                                    <option value="php" <?php selected($delivery_method, 'php'); ?>>
+                                        <?php _e('PHP（WordPressから直接配信）', $text_domain); ?>
+                                    </option>
+                                </select>
+                                <p class="description">
+                                    <?php _e('環境に合わせてメディアファイルの配信方法を選択してください。設定保存後は正しくメディアファイルが配信されるかを確認してください。', $text_domain); ?>
                                 </p>
                             </td>
                         </tr>

--- a/admin/classes/class-esp-admin-menu.php
+++ b/admin/classes/class-esp-admin-menu.php
@@ -425,6 +425,9 @@ class ESP_Admin_Menu {
                         <tr>
                             <th scope="row"><?php _e('配信方法', $text_domain); ?></th>
                             <td>
+                                <p class="description">
+                                    <?php _e('メディアファイルを保護するために当プラグインでメディアファイルへのアクセス認証を行い配信します。環境に合わせてメディアファイルの配信方法を選択してください。', $text_domain); ?>
+                                </p>
                                 <select name="<?php echo $option_key; ?>[media][delivery_method]" class="regular-text">
                                     <option value="auto" <?php selected($delivery_method, 'auto'); ?>>
                                         <?php _e('自動判定（利用可能な方法を選択）', $text_domain); ?>
@@ -443,7 +446,7 @@ class ESP_Admin_Menu {
                                     </option>
                                 </select>
                                 <p class="description">
-                                    <?php _e('環境に合わせてメディアファイルの配信方法を選択してください。設定保存後は正しくメディアファイルが配信されるかを確認してください。', $text_domain); ?>
+                                    <?php _e('設定保存後は正しくメディアファイルが配信されるかを確認してください。', $text_domain); ?>
                                 </p>
                             </td>
                         </tr>

--- a/admin/classes/class-esp-admin-sanitize.php
+++ b/admin/classes/class-esp-admin-sanitize.php
@@ -194,6 +194,26 @@ class ESP_Sanitize {
     }
 
     /**
+     * メディア設定のサニタイズ
+     */
+    public function sanitize_media_settings($settings) {
+        // 許可する配信方法の一覧
+        $allowed = array('auto', 'x_sendfile', 'litespeed', 'x_accel_redirect', 'php');
+        $delivery_method = 'auto';
+
+        if (is_array($settings) && isset($settings['delivery_method'])) {
+            $candidate = sanitize_text_field($settings['delivery_method']);
+            if (in_array($candidate, $allowed, true)) {
+                $delivery_method = $candidate;
+            }
+        }
+
+        return array(
+            'delivery_method' => $delivery_method
+        );
+    }
+
+    /**
      * メール設定のサニタイズ
      */
     public function sanitize_mail_settings($settings) {

--- a/admin/classes/class-esp-admin-setting.php
+++ b/admin/classes/class-esp-admin-setting.php
@@ -107,6 +107,11 @@ class ESP_Settings {
             isset($input['mail']) ? $input['mail'] : ESP_Option::get_current_setting('mail')
         );
 
+        // メディア設定のサニタイズ
+        $sanitized['media'] = $this->sanitize->sanitize_media_settings(
+            isset($input['media']) ? $input['media'] : ESP_Option::get_current_setting('media')
+        );
+
         return $sanitized;
     }
 

--- a/easy-slug-protect.php
+++ b/easy-slug-protect.php
@@ -3,7 +3,7 @@
  * Plugin Name: Easy Slug Protect
  * Plugin URI: https://github.com/ponpaku/wp-easy-slug-protect
  * Description: URLの階層（スラッグ）ごとにシンプルなパスワード保護を実現するプラグイン
- * Version: 0.7.14
+ * Version: 0.7.15
  * Author: ponpaku
  * Text Domain: easy-slug-protect
  * Domain Path: /languages
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 // プラグインの基本定数を定義
-define('ESP_VERSION', '0.7.14');
+define('ESP_VERSION', '0.7.15');
 define('ESP_PATH', plugin_dir_path(__FILE__));
 define('ESP_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-esp-config.php
+++ b/includes/class-esp-config.php
@@ -40,6 +40,9 @@ class ESP_Config {
                 'critical_error' => true
             )
         ),
+        'media' => array(
+            'delivery_method' => 'auto'
+        ),
         'db_version' => 4 // DBバージョン
 
     );


### PR DESCRIPTION
## Summary
- add a PHP delivery option to the media settings selector and clarify the description text
- allow the new PHP option through media settings sanitization
- document conditional branches in the media deriver and honor forced PHP delivery

## Testing
- php -l admin/classes/class-esp-admin-menu.php
- php -l admin/classes/class-esp-admin-sanitize.php
- php -l includes/class-esp-media-deriver.php

------
https://chatgpt.com/codex/tasks/task_e_68d40d0eb610833088154f464d8e743a