### PR TITLE
Refine LiteSpeed rewrite handling

### DIFF
--- a/admin/classes/class-esp-admin-sanitize.php
+++ b/admin/classes/class-esp-admin-sanitize.php
@@ -208,8 +208,24 @@ class ESP_Sanitize {
             }
         }
 
+        // 保存済みのLiteSpeedキーを優先的に維持
+        $current = ESP_Option::get_current_setting('media');
+        $stored_key = '';
+        if (is_array($current) && isset($current[ESP_Media_Protection::OPTION_LITESPEED_KEY])) {
+            $stored_key = sanitize_text_field($current[ESP_Media_Protection::OPTION_LITESPEED_KEY]);
+        }
+
+        // 新しい入力がある場合のみキーを更新
+        if (is_array($settings) && isset($settings[ESP_Media_Protection::OPTION_LITESPEED_KEY])) {
+            $candidate_key = sanitize_text_field($settings[ESP_Media_Protection::OPTION_LITESPEED_KEY]);
+            if ($candidate_key !== '') {
+                $stored_key = preg_replace('/[^a-zA-Z0-9]/', '', $candidate_key);
+            }
+        }
+
         return array(
-            'delivery_method' => $delivery_method
+            'delivery_method' => $delivery_method,
+            ESP_Media_Protection::OPTION_LITESPEED_KEY => $stored_key
         );
     }
 

--- a/includes/class-esp-config.php
+++ b/includes/class-esp-config.php
@@ -7,6 +7,7 @@ if (!defined('ABSPATH')) {
 class ESP_Config {
     const TEXT_DOMAIN = 'easy-slug-protect';
     const OPTION_KEY = 'esp_settings';
+    const LITESPEED_QUERY_KEY = 'esp_media_key';
     
     // バージョン管理用の定数を追加
     const VERSION_OPTION_KEY = 'esp_plugin_version';
@@ -41,7 +42,8 @@ class ESP_Config {
             )
         ),
         'media' => array(
-            'delivery_method' => 'auto'
+            'delivery_method' => 'auto',
+            'litespeed_key' => ''
         ),
         'db_version' => 4 // DBバージョン
 


### PR DESCRIPTION
## Summary
- add a clarifying comment for LiteSpeed key-based internal redirects in the media deriver
- ensure LiteSpeed-specific htaccess rules still include the shared PHP fallback rule used by Apache

## Testing
- php -l includes/class-esp-media-deriver.php
- php -l includes/class-esp-media-protection.php

------
https://chatgpt.com/codex/tasks/task_e_68d4bd9548cc83309c79511b8c781506