### PR TITLE
Fix duplicate ESP_Media_Protection instantiation

### DIFF
--- a/admin/classes/class-esp-admin-core.php
+++ b/admin/classes/class-esp-admin-core.php
@@ -51,9 +51,7 @@ class ESP_Admin_Page {
         $this->menu = new ESP_Admin_Menu();
         $this->assets = new ESP_Admin_Assets();
 
-        if (class_exists('ESP_Media_Protection')) {
-            // 管理画面でもメディア保護機能を有効化
-            $this->media_protection = new ESP_Media_Protection();
-        }
+        // 管理画面でもメディア保護機能を有効化
+        $this->media_protection = new ESP_Media_Protection();
     }
 }

--- a/admin/classes/class-esp-admin-core.php
+++ b/admin/classes/class-esp-admin-core.php
@@ -20,6 +20,11 @@ class ESP_Admin_Page {
      */
     private $assets;
 
+    /**
+     * @var ESP_Media_Protection
+     */
+    private $media_protection;
+
     public function __construct() {
         $this->load_dependencies();
         $this->initialize_components();
@@ -42,8 +47,13 @@ class ESP_Admin_Page {
         // シングルトンインスタンスを取得して初期化
         $settings = ESP_Settings::get_instance();
         $settings->init();
-        
+
         $this->menu = new ESP_Admin_Menu();
         $this->assets = new ESP_Admin_Assets();
+
+        if (class_exists('ESP_Media_Protection')) {
+            // 管理画面でもメディア保護機能を有効化
+            $this->media_protection = new ESP_Media_Protection();
+        }
     }
 }

--- a/easy-slug-protect.php
+++ b/easy-slug-protect.php
@@ -112,9 +112,6 @@ class Easy_Slug_Protect {
             add_action(ESP_Config::INTEGRITY_CHECK_HOOK, ['ESP_Filter', 'cron_check_and_fix_permalink_paths']);
         }
 
-        if (class_exists('ESP_Media_Protection')) {
-            new ESP_Media_Protection();
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove the redundant `ESP_Media_Protection` instantiation in `Easy_Slug_Protect::init()` to avoid double hook registration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f96f5078833083c348e459cdc0b5