### PR TITLE
Allow cron cache refresh to rebuild post cache

### DIFF
--- a/easy-slug-protect.php
+++ b/easy-slug-protect.php
@@ -98,6 +98,10 @@ class Easy_Slug_Protect {
         
         // クリーンアップタスクの実行（Setupで登録したcronから呼び出される）
         add_action(ESP_Config::DAILY_CLEANUP_HOOK, ['ESP_Setup', 'run_cleanup_tasks']);
+        // メディアキャッシュ更新
+        add_action('esp_media_cache_refresh', ['ESP_Setup', 'run_media_cache_refresh']);
+        // 全キャッシュ更新
+        add_action('esp_all_cache_refresh', ['ESP_Setup', 'run_all_cache_refresh']);
 
         // AJAXアクションのフック
         add_action('wp_loaded', function() {

--- a/includes/class-esp-filter.php
+++ b/includes/class-esp-filter.php
@@ -517,7 +517,10 @@ class ESP_Filter {
      * - メモリ使用量を監視して安全に中断
      */
     public function regenerate_protected_posts_cache() {
-        if (wp_doing_cron() && !defined('ESP_DOING_CRON_INTEGRITY_CHECK')) {
+        if (wp_doing_cron()
+            && !defined('ESP_DOING_CRON_INTEGRITY_CHECK')
+            && !defined('ESP_DOING_CRON_CACHE_REFRESH')
+        ) {
             return; // 通常の Cron ではスキップ
         }
 

--- a/includes/class-esp-setup.php
+++ b/includes/class-esp-setup.php
@@ -90,6 +90,9 @@ class ESP_Setup {
     public static function run_all_cache_refresh() {
         // 投稿保護キャッシュの更新
         if (class_exists('ESP_Filter')) {
+            if (!defined('ESP_DOING_CRON_CACHE_REFRESH')) {
+                define('ESP_DOING_CRON_CACHE_REFRESH', true);
+            }
             $filter = new ESP_Filter();
             $filter->regenerate_protected_posts_cache();
         }
@@ -217,7 +220,9 @@ class ESP_Setup {
         if (version_compare($current_version, ESP_VERSION, '<')) {
             // バージョンに応じた更新処理
             $this->update_check();
-            
+            // 新バージョンに合わせてCronを再登録
+            $this->schedule_cron_jobs();
+
             // バージョン情報を更新
             update_option(ESP_Config::VERSION_OPTION_KEY, ESP_VERSION);
         }


### PR DESCRIPTION
## Summary
- register cron handlers for media and full cache refresh events
- ensure the main plugin file ends with a newline character
- allow the full cache refresh cron job to rebuild post caches by defining a dedicated cron flag
- reschedule cron jobs after version upgrades so new events are registered automatically

## Testing
- php -l includes/class-esp-setup.php

------
https://chatgpt.com/codex/tasks/task_e_68e9ef3a3e488330a0107d59351d95b0